### PR TITLE
fix(frontend): layouting fix for responsiveness

### DIFF
--- a/frontend/src/containers/landing/landing.styles.ts
+++ b/frontend/src/containers/landing/landing.styles.ts
@@ -3,13 +3,14 @@ import styled from "styled-components";
 export const LandingWrapper = styled.div`
     width: 100%;
     height: 100%;
-    max-width: 50rem;
+    max-width: 60rem;
     
     display: grid;
     gap: 2rem;
 
     margin: auto;
-    padding: 2rem;
+    padding: 1rem 0;
+    padding-bottom: 2rem;
     box-sizing: border-box;
 
     background-color: var(--bg-secondary-color);
@@ -27,11 +28,19 @@ export const LandingHeader = styled.div`
 export const LandingImg = styled.img`
     max-width: 50%;
     height: auto;
+
+    @media only screen and (max-height: 780px) {
+        max-width: 35%;
+    }
+    @media only screen and (max-width: 500px) {
+        max-width: 50%;
+    }
 `
 
 export const LandingTaglines = styled.div`
     text-align: end;
     display: flex;
+    max-width: 40%;
 
     flex-direction: column;
     gap: 1rem;


### PR DESCRIPTION
## Fixes #5 

## Description
- The width and height of the view-take of the logo has been modified to take lesser space in shorter screens.
- The padding along the top and the sides of the landing page have been reduced to `1rem` than `2rem`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Tested in multiple view-ports, and works as expected.

- [x] Locally Tested
